### PR TITLE
Allow users to create, deactivate, remove their MFA devices

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_iam_policy" "mfa_policy" {
                 "iam:ResyncMFADevice"
             ],
             "Resource": [
-                "arn:aws:iam::*:mfa/$${aws:username}",
+                "arn:aws:iam::*:mfa/*",
                 "arn:aws:iam::*:user/$${aws:username}"
             ]
         },
@@ -130,7 +130,7 @@ resource "aws_iam_policy" "mfa_policy" {
                 "iam:DeactivateMFADevice"
             ],
             "Resource": [
-                "arn:aws:iam::*:mfa/$${aws:username}",
+                "arn:aws:iam::*:mfa/*",
                 "arn:aws:iam::*:user/$${aws:username}"
             ],
             "Condition": {


### PR DESCRIPTION
- AWS now support mulitple MFA devices. This change aims to update the policy to allow for those AWS changes.
- Announcement: https://aws.amazon.com/blogs/security/you-can-now-assign-multiple-mfa-devices-in-iam/
- This is scoped on username which causes the user "things" created not be unique and so this does not allow to create multiple MFA devices.
